### PR TITLE
Upgrade teresa-cli to v0.5.0

### DIFF
--- a/Formula/teresa-cli.rb
+++ b/Formula/teresa-cli.rb
@@ -1,10 +1,10 @@
 class TeresaCli < Formula
   desc "Teresa client"
   homepage "https://github.com/luizalabs/teresa-cli"
-  url "https://github.com/luizalabs/teresa-cli/releases/download/v0.3.2/teresa-darwin-amd64"
-  sha256 "ba2fa97159cfba6705966e96864eca9e6704bcd63a16ff11d3943a7d4ac0d326"
-  head "https://github.com/luizalabs/teresa-cli.git"
-  version 'v0.3.2'
+  url "https://github.com/luizalabs/teresa/releases/download/v0.5.0/teresa-darwin-amd64"
+  sha256 "d48b7ce9768ad66c2b074e0eddd2e5a58f0042d99deba78f7b103a6a1a4f0e30"
+  head "https://github.com/luizalabs/teresa.git"
+  version 'v0.5.0'
 
   bottle :unneeded
 

--- a/Formula/teresa-cli.rb
+++ b/Formula/teresa-cli.rb
@@ -1,6 +1,6 @@
 class TeresaCli < Formula
   desc "Teresa client"
-  homepage "https://github.com/luizalabs/teresa-cli"
+  homepage "https://github.com/luizalabs/teresa"
   url "https://github.com/luizalabs/teresa/releases/download/v0.5.0/teresa-darwin-amd64"
   sha256 "d48b7ce9768ad66c2b074e0eddd2e5a58f0042d99deba78f7b103a6a1a4f0e30"
   head "https://github.com/luizalabs/teresa.git"


### PR DESCRIPTION
🎉 

```bash
~/projects/homebrew-teresa-cli (master)
 ⟩ brew info teresa-cli
tromulooliveira/teresa-cli/teresa-cli: stable v0.5.0, HEAD
Teresa client
https://github.com/luizalabs/teresa-cli
/usr/local/Cellar/teresa-cli/v0.3.2 (3 files, 13.4MB)
  Built from source on 2017-04-12 at 16:47:10
/usr/local/Cellar/teresa-cli/v0.5.0 (3 files, 13.8MB) *
  Built from source on 2017-08-15 at 17:42:52
eFrom: https://github.com/RomuloOliveira/homebrew-teresa-cli/blob/master/Formula/teresa-cli.rb
~/projects/homebrew-teresa-cli (master)
 ⟩ teresa version
Version: v0.5.0
```