### PR TITLE
Upgrade version to v0.11.0

### DIFF
--- a/Formula/teresa-cli.rb
+++ b/Formula/teresa-cli.rb
@@ -1,10 +1,10 @@
 class TeresaCli < Formula
   desc "Teresa client"
   homepage "https://github.com/luizalabs/teresa"
-  url "https://github.com/luizalabs/teresa/releases/download/v0.10.0/teresa-darwin-amd64"
-  sha256 "cda28441bf35f80954f5640e9ba6a9c60a76024062511e3de8b611c773b58af9"
+  url "https://github.com/luizalabs/teresa/releases/download/v0.11.0/teresa-darwin-amd64"
+  sha256 "183890149cbb14288e691926a3baa22633250fce61b4f82b116f918cf66d57b1"
   head "https://github.com/luizalabs/teresa.git"
-  version 'v0.10.0'
+  version 'v0.11.0'
 
   bottle :unneeded
 


### PR DESCRIPTION
Tested in OSX High Sierra:

```
⟩ brew install teresa-cli
==> Installing teresa-cli from romulooliveira/teresa-cli
==> Downloading https://github.com/luizalabs/teresa/releases/download/v0.11.0/teresa-darwin-amd64
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/2869673/192c1d58-de8c-11e7-9234-a785ef89
######################################################################## 100.0%
==> cp teresa-darwin-amd64 teresa
🍺  /usr/local/Cellar/teresa-cli/v0.11.0: 3 files, 23.6MB, built in 8 seconds
 ⟩ teresa version
Version: v0.11.0
```